### PR TITLE
Fix level preview loading in WASM build

### DIFF
--- a/src/editor/example_browser.rs
+++ b/src/editor/example_browser.rs
@@ -31,6 +31,8 @@ pub struct ExampleBrowser {
     pub last_mouse: (f32, f32),
     /// Scroll offset for the list
     pub scroll_offset: f32,
+    /// Path pending async load (WASM)
+    pub pending_load_path: Option<std::path::PathBuf>,
 }
 
 impl Default for ExampleBrowser {
@@ -48,6 +50,7 @@ impl Default for ExampleBrowser {
             dragging: false,
             last_mouse: (0.0, 0.0),
             scroll_offset: 0.0,
+            pending_load_path: None,
         }
     }
 }

--- a/src/editor/example_levels.rs
+++ b/src/editor/example_levels.rs
@@ -91,11 +91,25 @@ pub async fn load_example_level(path: &PathBuf) -> Option<Level> {
     #[cfg(target_arch = "wasm32")]
     {
         use macroquad::prelude::*;
-        let path_str = path.to_string_lossy();
+        // Convert path to string for fetch - ensure forward slashes
+        let path_str = path.to_string_lossy().replace('\\', "/");
+        macroquad::logging::info!("load_example_level: fetching {}", path_str);
         match load_string(&path_str).await {
-            Ok(contents) => load_level_from_str(&contents).ok(),
+            Ok(contents) => {
+                macroquad::logging::info!("load_example_level: got {} bytes", contents.len());
+                match load_level_from_str(&contents) {
+                    Ok(level) => {
+                        macroquad::logging::info!("load_example_level: parsed {} rooms", level.rooms.len());
+                        Some(level)
+                    }
+                    Err(e) => {
+                        macroquad::logging::error!("load_example_level: parse error: {}", e);
+                        None
+                    }
+                }
+            }
             Err(e) => {
-                eprintln!("Failed to load example level: {}", e);
+                macroquad::logging::error!("load_example_level: fetch error: {}", e);
                 None
             }
         }


### PR DESCRIPTION
- Add pending_load_path field to ExampleBrowser for async loading
- Handle async level loading in main loop for WASM target
- Add debug logging to trace level loading issues