### PR TITLE
Add manifest generation for models and meshes in build.rs

### DIFF
--- a/assets/meshes/manifest.txt
+++ b/assets/meshes/manifest.txt
@@ -1,0 +1,4 @@
+clockwork.obj
+crawler.obj
+ghost.obj
+warrior.obj

--- a/assets/models/manifest.txt
+++ b/assets/models/manifest.txt
@@ -1,0 +1,3 @@
+model_001.ron
+model_002.ron
+model_003.ron


### PR DESCRIPTION
This enables the model and mesh browsers to work on WASM builds by generating manifest.txt files that list available assets at build time.
