### PR TITLE
Add dev deployment workflow for preview builds

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,54 @@
+name: Deploy Dev Build
+
+# Deploys feature branches to /dev/ subdirectory
+# Access at: https://ebonura.github.io/bonnie-engine/dev/
+
+on:
+  push:
+    branches:
+      - 'dev/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Build WASM
+        run: cargo build --release --target wasm32-unknown-unknown
+
+      - name: Download macroquad JS bundle
+        run: curl -L -o mq_js_bundle.js https://raw.githubusercontent.com/not-fl3/macroquad/v0.4.14/js/mq_js_bundle.js
+
+      - name: Prepare dev folder
+        run: |
+          mkdir -p dev-build
+          cp target/wasm32-unknown-unknown/release/bonnie-engine.wasm dev-build/
+          cp docs/index.html dev-build/
+          cp docs/audio-processor.js dev-build/
+          cp docs/favicon-16.png dev-build/
+          cp docs/favicon-32.png dev-build/
+          cp docs/apple-touch-icon.png dev-build/
+          cp mq_js_bundle.js dev-build/
+          cp -r assets dev-build/
+
+          # Add a banner to indicate this is a dev build
+          sed -i 's|Loading Bonnie Engine|Loading Bonnie Engine (DEV)|g' dev-build/index.html
+          sed -i 's|<title>Bonnie Engine|<title>[DEV] Bonnie Engine|g' dev-build/index.html
+
+      - name: Deploy to gh-pages /dev/ folder
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dev-build
+          destination_dir: dev
+          keep_files: true  # Don't delete other files (preserves main build at root)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,22 @@
 name: Deploy to GitHub Pages
 
+# Deploys main branch to root of GitHub Pages
+# Access at: https://ebonura.github.io/bonnie-engine/
+
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: "pages"
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,18 +44,9 @@ jobs:
           cp mq_js_bundle.js deploy/
           cp -r assets deploy/
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages root
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: deploy
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./deploy
+          keep_files: true  # Preserve /dev/ folder


### PR DESCRIPTION
- Add deploy-dev.yml: deploys non-main branches to /dev/ subdirectory
- Update deploy.yml: use gh-pages branch with keep_files to preserve /dev/
- Dev builds show [DEV] in title and loading screen

URLs:
- Production: https://ebonura.github.io/bonnie-engine/
- Dev preview: https://ebonura.github.io/bonnie-engine/dev/
