### PR TITLE
Add 4:3 aspect ratio toggle to in-game debug menu

### DIFF
--- a/src/rasterizer/types.rs
+++ b/src/rasterizer/types.rs
@@ -1114,7 +1114,7 @@ impl Default for RasterSettings {
             ambient: 0.3,
             low_resolution: true,   // PS1 default: 320x240
             dithering: true,        // PS1 default: dithering enabled for smooth gradients
-            stretch_to_fill: true,  // Default: use full viewport space
+            stretch_to_fill: false, // Default: 4:3 aspect ratio with letterboxing
             wireframe_overlay: false, // Default: wireframe off
             ortho_projection: None,  // Default: perspective projection
             use_rgb555: true,        // PS1 default: 15-bit color mode


### PR DESCRIPTION
- Add '4:3 Aspect' option to debug menu (index 6)
- When disabled (stretch mode): scale horizontal resolution to match viewport
- When enabled (default): maintain 4:3 with letterboxing
- Default to 4:3 mode (stretch_to_fill: false)