### PR TITLE
Fix release workflow: use correct rust-toolchain action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
 
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
 


### PR DESCRIPTION
The action was incorrectly named "dtolnay/rust-action" but the correct name is "dtolnay/rust-toolchain".

🤖 Generated with [Claude Code](https://claude.com/claude-code)