### PR TITLE
Fix WASM mesh browser and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,16 +179,21 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Get version
         id: version
         run: |
+          # Always use Cargo.toml version for artifact names (they're built with this version)
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=$CARGO_VERSION" >> $GITHUB_OUTPUT
+
+          # Use tag name for the release tag (could be different, e.g., v0.1.5b)
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
+            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
-            VERSION=${{ needs.check-version.outputs.version }}
+            echo "tag=v$CARGO_VERSION" >> $GITHUB_OUTPUT
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "bonnie-engine"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64 0.22.1",
  "brotli",

--- a/src/modeler/mesh_browser.rs
+++ b/src/modeler/mesh_browser.rs
@@ -150,9 +150,26 @@ pub async fn load_mesh(path: &PathBuf) -> Option<EditableMesh> {
     use macroquad::prelude::*;
 
     let path_str = path.to_string_lossy().replace('\\', "/");
+    eprintln!("[mesh_browser] Loading mesh from: {}", path_str);
+
     match load_string(&path_str).await {
-        Ok(contents) => ObjImporter::parse(&contents).ok(),
-        Err(_) => None,
+        Ok(contents) => {
+            eprintln!("[mesh_browser] Loaded {} bytes, parsing OBJ...", contents.len());
+            match ObjImporter::parse(&contents) {
+                Ok(mesh) => {
+                    eprintln!("[mesh_browser] Parsed: {} vertices, {} faces", mesh.vertices.len(), mesh.faces.len());
+                    Some(mesh)
+                }
+                Err(e) => {
+                    eprintln!("[mesh_browser] OBJ parse error: {}", e);
+                    None
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("[mesh_browser] Failed to load mesh file {}: {}", path_str, e);
+            None
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix WASM mesh browser not applying scale/flip transforms
- Fix release workflow artifact name mismatch when tag differs from Cargo.toml version

## Changes

### Mesh Browser WASM Fixes
- Apply `import_scale` to mesh vertices during async load
- Apply `flip_normals`, `flip_horizontal`, `flip_vertical` transforms
- Update `MeshInfo.vertex_count` and `face_count` after loading (were always 0)
- Add error logging for debugging WASM mesh loading
- Handle `ReloadPreview` action in WASM by queuing async reload

### Release Workflow Fix
- Release step now reads version from Cargo.toml for artifact names
- Tag name can differ from Cargo version (e.g., `v0.1.5b` tag with `0.1.5` in Cargo.toml)
- Fixes issue where v0.1.5b release had no binaries attached

## Test plan
- [x] WASM mesh browser shows correct vertex/face counts
- [x] Meshes display at correct scale in WASM
- [x] Scale +/- buttons work in WASM mesh browser
- [ ] Next release should have binaries attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)